### PR TITLE
Fix link commands injection

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ module.exports = {
       throw(e);
     }
 
-    if (inputs.linkCommands && inputs.linkCommands.length > 0) {
+    if (inputs.linkCommands) {
       try {
         const linkCommandsSnippet = getLinkCommandsSnippet(inputs.linkCommands);
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "index.js",
     "manifest.yml"
   ],
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "CommandBar plugin for sites deployed to Netlify",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Remove check for `inputs.linkCommands.length > 0` because `inputs.linkCommands` is not an array, it is an object.